### PR TITLE
sortableHeader: allow passing getSortingColumns

### DIFF
--- a/src/extensions/sortable-header.js
+++ b/src/extensions/sortable-header.js
@@ -2,6 +2,7 @@ import * as sort from 'sortabular';
 
 function sortableHeader({
   sortingColumns,
+  getSortingColumns,
   onSort,
   props,
   strategy
@@ -11,7 +12,7 @@ function sortableHeader({
       return header.sortable;
     },
     evaluate() {
-      const getSortingColumns = () => sortingColumns || {};
+      getSortingColumns = getSortingColumns || (() => sortingColumns || {});
       const sortable = sort.sort({
         getSortingColumns,
         onSort: (selectedColumn) => {


### PR DESCRIPTION
If you generate the column list outside of the render function, you don't have the correct `sortingColumns` available. In that situation it is useful to use `getSortingColumns`.