### PR TITLE
Fix for dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
   "bugs": {
     "url": "https://github.com/reactabular/column-extensions/issues"
   },
-  "dependencies": {},
+  "dependencies": {
+    "reactabular-resizable": "^8.4.0"
+  },
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-core": "^6.18.2",


### PR DESCRIPTION
The peer dependency mandate reactabular-resizable but, dependencies don't. Not sure of any functionality break. But just don't like the build error.